### PR TITLE
Connect role pills into snake-style button groups

### DIFF
--- a/assets/css/landing.scss
+++ b/assets/css/landing.scss
@@ -122,12 +122,8 @@ body {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 0.6rem;
+  gap: 0.5rem 0;
   margin-bottom: 2rem;
-
-  @include MQ(M) {
-    gap: 0.75rem;
-  }
 }
 
 .role-btn {
@@ -139,15 +135,19 @@ body {
   font-size: 0.9rem;
   font-weight: 500;
   padding: 0.5rem 1.25rem;
-  border-radius: 100px;
+  border-radius: 0;
   cursor: pointer;
   transition: all 0.2s ease;
   white-space: nowrap;
+  margin-left: -1.5px;
+  position: relative;
+  z-index: 0;
 
   &:hover {
     border-color: $accent;
     color: $accent;
     background: $accent-light;
+    z-index: 1;
   }
 
   &.is-active {
@@ -155,6 +155,17 @@ body {
     color: #fff;
     border-color: $accent;
     box-shadow: $shadow-sm;
+    z-index: 2;
+  }
+
+  &.snake-left {
+    border-top-left-radius: 100px;
+    border-bottom-left-radius: 100px;
+  }
+
+  &.snake-right {
+    border-top-right-radius: 100px;
+    border-bottom-right-radius: 100px;
   }
 
   @include MQ(M) {

--- a/assets/css/landing.scss
+++ b/assets/css/landing.scss
@@ -124,6 +124,15 @@ body {
   justify-content: center;
   gap: 0.5rem 0;
   margin-bottom: 2rem;
+  position: relative;
+}
+
+.snake-svg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  pointer-events: none;
+  overflow: visible;
 }
 
 .role-btn {

--- a/assets/css/landing.scss
+++ b/assets/css/landing.scss
@@ -121,8 +121,8 @@ body {
 .roles {
   display: flex;
   flex-wrap: wrap;
-  justify-content: center;
-  gap: 0.5rem 0;
+  justify-content: flex-start;
+  gap: 3rem 0;
   margin-bottom: 2rem;
   position: relative;
 }
@@ -133,6 +133,7 @@ body {
   left: 0;
   pointer-events: none;
   overflow: visible;
+  z-index: 0;
 }
 
 .role-btn {
@@ -150,13 +151,13 @@ body {
   white-space: nowrap;
   margin-left: -1.5px;
   position: relative;
-  z-index: 0;
+  z-index: 1;
 
   &:hover {
     border-color: $accent;
     color: $accent;
     background: $accent-light;
-    z-index: 1;
+    z-index: 2;
   }
 
   &.is-active {
@@ -164,7 +165,7 @@ body {
     color: #fff;
     border-color: $accent;
     box-shadow: $shadow-sm;
-    z-index: 2;
+    z-index: 3;
   }
 
   &.snake-left {

--- a/index.html
+++ b/index.html
@@ -67,14 +67,17 @@ layout: landing
       });
     });
 
-    // Snake corners: detect which buttons start/end each visual row
-    // and apply rounded ends so each wrapped row forms a connected pill strip
-    function updateSnakeCorners() {
+    // Snake layout: detect visual rows, round outer ends,
+    // and draw curved SVG connectors between consecutive rows
+    var container = document.querySelector('.roles');
+
+    function updateSnake() {
       buttons.forEach(function (b) {
         b.classList.remove('snake-left', 'snake-right');
       });
       if (buttons.length === 0) return;
 
+      // Group buttons into visual rows by offsetTop
       var rows = [];
       var currentRow = [buttons[0]];
       var currentTop = buttons[0].offsetTop;
@@ -90,13 +93,56 @@ layout: landing
       }
       rows.push(currentRow);
 
-      rows.forEach(function (row) {
+      // Round corners — skip the attachment edge where a connector joins
+      rows.forEach(function (row, idx) {
         row[0].classList.add('snake-left');
         row[row.length - 1].classList.add('snake-right');
       });
+
+      // Draw SVG connectors between consecutive rows
+      var svg = container.querySelector('.snake-svg');
+      if (!svg) {
+        svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+        svg.setAttribute('class', 'snake-svg');
+        container.appendChild(svg);
+      }
+      svg.setAttribute('width', container.offsetWidth);
+      svg.setAttribute('height', container.offsetHeight);
+      svg.innerHTML = '';
+
+      var cRect = container.getBoundingClientRect();
+
+      for (var r = 0; r < rows.length - 1; r++) {
+        var lastBtn = rows[r][rows[r].length - 1];
+        var firstBtn = rows[r + 1][0];
+        var lRect = lastBtn.getBoundingClientRect();
+        var fRect = firstBtn.getBoundingClientRect();
+
+        // Start: right edge of last button, vertically centered
+        var x1 = lRect.right - cRect.left;
+        var y1 = (lRect.top + lRect.bottom) / 2 - cRect.top;
+        // End: left edge of first button of next row, vertically centered
+        var x2 = fRect.left - cRect.left;
+        var y2 = (fRect.top + fRect.bottom) / 2 - cRect.top;
+
+        // Connector bulges to the right of the rightmost point
+        var xPeak = Math.max(x1, x2) + 24;
+
+        var path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        path.setAttribute('d',
+          'M ' + x1 + ' ' + y1 +
+          ' C ' + xPeak + ' ' + y1 +
+          ', ' + xPeak + ' ' + y2 +
+          ', ' + x2 + ' ' + y2
+        );
+        path.setAttribute('fill', 'none');
+        path.setAttribute('stroke', '#e8e8e8');
+        path.setAttribute('stroke-width', '1.5');
+        svg.appendChild(path);
+      }
     }
 
-    updateSnakeCorners();
-    window.addEventListener('resize', updateSnakeCorners);
+    updateSnake();
+    window.addEventListener('resize', updateSnake);
   })();
 </script>

--- a/index.html
+++ b/index.html
@@ -66,5 +66,37 @@ layout: landing
         }
       });
     });
+
+    // Snake corners: detect which buttons start/end each visual row
+    // and apply rounded ends so each wrapped row forms a connected pill strip
+    function updateSnakeCorners() {
+      buttons.forEach(function (b) {
+        b.classList.remove('snake-left', 'snake-right');
+      });
+      if (buttons.length === 0) return;
+
+      var rows = [];
+      var currentRow = [buttons[0]];
+      var currentTop = buttons[0].offsetTop;
+
+      for (var i = 1; i < buttons.length; i++) {
+        if (Math.abs(buttons[i].offsetTop - currentTop) > 2) {
+          rows.push(currentRow);
+          currentRow = [buttons[i]];
+          currentTop = buttons[i].offsetTop;
+        } else {
+          currentRow.push(buttons[i]);
+        }
+      }
+      rows.push(currentRow);
+
+      rows.forEach(function (row) {
+        row[0].classList.add('snake-left');
+        row[row.length - 1].classList.add('snake-right');
+      });
+    }
+
+    updateSnakeCorners();
+    window.addEventListener('resize', updateSnakeCorners);
   })();
 </script>

--- a/index.html
+++ b/index.html
@@ -67,21 +67,22 @@ layout: landing
       });
     });
 
-    // Snake layout: detect visual rows, round outer ends,
-    // and draw curved SVG connectors between consecutive rows
+    // Snake layout: connect pills into a continuous tube shape
     var container = document.querySelector('.roles');
 
     function updateSnake() {
+      // Reset classes and SVG
       buttons.forEach(function (b) {
         b.classList.remove('snake-left', 'snake-right');
       });
+      var oldSvg = container.querySelector('.snake-svg');
+      if (oldSvg) oldSvg.remove();
       if (buttons.length === 0) return;
 
       // Group buttons into visual rows by offsetTop
       var rows = [];
       var currentRow = [buttons[0]];
       var currentTop = buttons[0].offsetTop;
-
       for (var i = 1; i < buttons.length; i++) {
         if (Math.abs(buttons[i].offsetTop - currentTop) > 2) {
           rows.push(currentRow);
@@ -93,52 +94,70 @@ layout: landing
       }
       rows.push(currentRow);
 
-      // Round corners — skip the attachment edge where a connector joins
-      rows.forEach(function (row, idx) {
-        row[0].classList.add('snake-left');
-        row[row.length - 1].classList.add('snake-right');
-      });
-
-      // Draw SVG connectors between consecutive rows
-      var svg = container.querySelector('.snake-svg');
-      if (!svg) {
-        svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-        svg.setAttribute('class', 'snake-svg');
-        container.appendChild(svg);
+      // Single row: round both ends, no connector needed
+      if (rows.length <= 1) {
+        rows[0][0].classList.add('snake-left');
+        rows[0][rows[0].length - 1].classList.add('snake-right');
+        return;
       }
-      svg.setAttribute('width', container.offsetWidth);
-      svg.setAttribute('height', container.offsetHeight);
-      svg.innerHTML = '';
+
+      // Round free ends: first row left, last row right
+      rows[0][0].classList.add('snake-left');
+      rows[rows.length - 1][rows[rows.length - 1].length - 1].classList.add('snake-right');
+
+      // Create SVG for tube connectors (inserted first so buttons stack above)
+      var svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      svg.setAttribute('class', 'snake-svg');
+      container.insertBefore(svg, container.firstChild);
 
       var cRect = container.getBoundingClientRect();
+      var btnH = buttons[0].offsetHeight;
+      var half = btnH / 2;
+      svg.style.width = (container.offsetWidth + btnH * 2) + 'px';
+      svg.style.height = (container.offsetHeight + btnH) + 'px';
 
+      // Draw tube connector wrapping right → bottom → left
+      // Center line runs OUTSIDE button edges by half so inner wall aligns flush
       for (var r = 0; r < rows.length - 1; r++) {
-        var lastBtn = rows[r][rows[r].length - 1];
-        var firstBtn = rows[r + 1][0];
-        var lRect = lastBtn.getBoundingClientRect();
-        var fRect = firstBtn.getBoundingClientRect();
+        var topLast = rows[r][rows[r].length - 1];
+        var botFirst = rows[r + 1][0];
+        var topRect = topLast.getBoundingClientRect();
+        var botRect = botFirst.getBoundingClientRect();
 
-        // Start: right edge of last button, vertically centered
-        var x1 = lRect.right - cRect.left;
-        var y1 = (lRect.top + lRect.bottom) / 2 - cRect.top;
-        // End: left edge of first button of next row, vertically centered
-        var x2 = fRect.left - cRect.left;
-        var y2 = (fRect.top + fRect.bottom) / 2 - cRect.top;
+        var xR = topRect.right - cRect.left;
+        var y1 = topRect.top + topRect.height / 2 - cRect.top;
+        var xL = botRect.left - cRect.left;
+        var y2 = botRect.top + botRect.height / 2 - cRect.top;
+        var yMid = (y1 + y2) / 2;
 
-        // Connector bulges to the right of the rightmost point
-        var xPeak = Math.max(x1, x2) + 24;
+        // Start inside row1's last button, extend right (center at xR+half),
+        // down, left across bottom (center at yMid), down, into row2's first button
+        var d = 'M' + xR + ',' + y1 +
+                ' L' + (xR + half) + ',' + y1 +
+                ' L' + (xR + half) + ',' + yMid +
+                ' L' + (xL - half) + ',' + yMid +
+                ' L' + (xL - half) + ',' + y2 +
+                ' L' + xL + ',' + y2;
 
-        var path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-        path.setAttribute('d',
-          'M ' + x1 + ' ' + y1 +
-          ' C ' + xPeak + ' ' + y1 +
-          ', ' + xPeak + ' ' + y2 +
-          ', ' + x2 + ' ' + y2
-        );
-        path.setAttribute('fill', 'none');
-        path.setAttribute('stroke', '#e8e8e8');
-        path.setAttribute('stroke-width', '1.5');
-        svg.appendChild(path);
+        // Border path
+        var borderP = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        borderP.setAttribute('d', d);
+        borderP.setAttribute('fill', 'none');
+        borderP.setAttribute('stroke', '#e8e8e8');
+        borderP.setAttribute('stroke-width', btnH + 3);
+        borderP.setAttribute('stroke-linecap', 'butt');
+        borderP.setAttribute('stroke-linejoin', 'round');
+        svg.appendChild(borderP);
+
+        // Fill path
+        var fillP = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        fillP.setAttribute('d', d);
+        fillP.setAttribute('fill', 'none');
+        fillP.setAttribute('stroke', '#ffffff');
+        fillP.setAttribute('stroke-width', btnH);
+        fillP.setAttribute('stroke-linecap', 'butt');
+        fillP.setAttribute('stroke-linejoin', 'round');
+        svg.appendChild(fillP);
       }
     }
 


### PR DESCRIPTION
Remove gaps between role buttons so they share borders and form connected strips per row. JS detects row boundaries on load and resize, applying rounded ends to the first/last button of each visual row for a fluid snake-wrapping button group effect.

https://claude.ai/code/session_015EpQhWWRzxizWimevDoCT6