### PR TITLE
Refresh homepage copy and role pills

### DIFF
--- a/_includes/roles/blimp-pilot.html
+++ b/_includes/roles/blimp-pilot.html
@@ -1,4 +1,4 @@
-<h3 class="subsection__title">Blimp Pilot <span class="coming-soon">coming soon</span></h3>
+<h3 class="subsection__title">blimp pilot <span class="coming-soon">coming soon</span></h3>
 <div class="subsection__body">
-  <p>Yes, really. There's nothing quite like navigating a lighter-than-air ship. It's slow, deliberate, and an entirely different way to see the world.</p>
+  <p>i think this would be super awesome. please reach out if you have a connection to teachers or certification programs.</p>
 </div>

--- a/_includes/roles/builder.html
+++ b/_includes/roles/builder.html
@@ -1,4 +1,4 @@
-<h3 class="subsection__title">Builder</h3>
+<h3 class="subsection__title">builder</h3>
 <div class="subsection__body">
-  <p>Software engineer at heart. I love turning ideas into products &mdash; from architecture to deployment. Always tinkering, always shipping.</p>
+  <p>software engineer by trade, but a builder at heart. historically; more ideas than time. now; the same 😅 but agentic tools sure has closed the gap.</p>
 </div>

--- a/_includes/roles/chef.html
+++ b/_includes/roles/chef.html
@@ -1,4 +1,4 @@
-<h3 class="subsection__title">Chef <span class="coming-soon">coming soon</span></h3>
+<h3 class="subsection__title">chef <span class="coming-soon">coming soon</span></h3>
 <div class="subsection__body">
-  <p>Cooking is creative problem-solving with a delicious reward. I love experimenting in the kitchen &mdash; from weeknight dinners to weekend projects.</p>
+  <p>culinary school <s>coming soon</s> maybe one day.</p>
 </div>

--- a/_includes/roles/father.html
+++ b/_includes/roles/father.html
@@ -1,4 +1,0 @@
-<h3 class="subsection__title">Father</h3>
-<div class="subsection__body">
-  <p>The most rewarding and humbling role. Every day is a new lesson in patience, wonder, and showing up.</p>
-</div>

--- a/_includes/roles/husband.html
+++ b/_includes/roles/husband.html
@@ -1,4 +1,4 @@
-<h3 class="subsection__title">Husband</h3>
+<h3 class="subsection__title">husband + dad</h3>
 <div class="subsection__body">
-  <p>Happily married and building a life together. Partnership, patience, and a shared sense of humor keep it all moving forward.</p>
+  <p>high school sweethearts with an added mix of two lovable tornadoes. two lessons: 1) patience, 2) black coffee, and 3) off-by-one errors.</p>
 </div>

--- a/_includes/roles/marathoner.html
+++ b/_includes/roles/marathoner.html
@@ -1,4 +1,7 @@
-<h3 class="subsection__title">Marathoner</h3>
+<h3 class="subsection__title">marathoner</h3>
 <div class="subsection__body">
-  <p>Lacing up and hitting the road is how I reset. Whether it's a quick morning run or a long weekend miles session, it keeps me grounded.</p>
+  <p>from couch to 5k to ... 26.2 awful miles. wacky hobby #2 started with</p>
+  <blockquote><em>"I'm going to run the NYC marathon"</em></blockquote>
+  <p>to unfortunately actually doing it.</p>
+  <p>but proudly finished it in November 2025. marathoner ✅, but still not a runner.</p>
 </div>

--- a/_includes/roles/sommelier.html
+++ b/_includes/roles/sommelier.html
@@ -1,4 +1,6 @@
-<h3 class="subsection__title">Sommelier</h3>
+<h3 class="subsection__title">sommelier</h3>
 <div class="subsection__body">
-  <p>Wine is as much about place, people, and memory as it is about the glass in front of you. I love exploring what makes a region tick and finding bottles that tell a real story.</p>
+  <p>terroir, old school farming, and centuries of tradition and craftsmanship &mdash; the final product's enjoyment doesn't hurt either!</p>
+  <p>Court of Master Sommeliers certified in December 2019.</p>
+  <p>wacky hobby numero uno.</p>
 </div>

--- a/assets/css/landing.scss
+++ b/assets/css/landing.scss
@@ -236,6 +236,14 @@ body {
     margin-bottom: 0.35em;
   }
 
+  blockquote {
+    margin: 0.25rem 0 1em;
+    padding: 0.1rem 0 0.1rem 1rem;
+    border-left: 3px solid $accent;
+    color: $text-primary;
+    font-style: italic;
+  }
+
   @include MQ(M) {
     font-size: 1rem;
   }

--- a/index.html
+++ b/index.html
@@ -5,25 +5,21 @@ layout: landing
   <section class="hero">
     <img src="{{ site.baseurl }}/static/img/photo.jpg" alt="Steven Rogers" class="hero__photo">
     <h1 class="hero__name">Steven Rogers</h1>
-    <p class="hero__blurb">Software engineer, family man, and collector of unlikely hobbies. Based in NYC, working at the intersection of curiosity and craft.</p>
+    <p class="hero__blurb">husband + dad, <s>engineering</s> builder, unrelated wacky hobbies, and working on the intersection of code &amp; craft.</p>
   </section>
 
   <nav class="roles" aria-label="Roles">
-    <button class="role-btn" data-role="husband">Husband</button>
-    <button class="role-btn" data-role="father">Father</button>
-    <button class="role-btn" data-role="builder">Builder</button>
-    <button class="role-btn" data-role="sommelier">Sommelier</button>
-    <button class="role-btn" data-role="marathoner">Marathoner</button>
-    <button class="role-btn" data-role="blimp-pilot">Blimp Pilot</button>
-    <button class="role-btn" data-role="chef">Chef</button>
+    <button class="role-btn" data-role="husband">husband + dad</button>
+    <button class="role-btn" data-role="builder">builder</button>
+    <button class="role-btn" data-role="sommelier">sommelier</button>
+    <button class="role-btn" data-role="marathoner">marathoner</button>
+    <button class="role-btn" data-role="blimp-pilot">blimp pilot</button>
+    <button class="role-btn" data-role="chef">chef</button>
   </nav>
 
   <div class="subsections">
     <div class="subsection" data-section="husband">
       {% include roles/husband.html %}
-    </div>
-    <div class="subsection" data-section="father">
-      {% include roles/father.html %}
     </div>
     <div class="subsection" data-section="builder">
       {% include roles/builder.html %}


### PR DESCRIPTION
## Summary

Rewrites the homepage hero blurb and all role-pill content into a lowercase, casual voice, and restructures the pills.

### Content
- **Hero blurb** → `husband + dad, ~~engineering~~ builder, unrelated wacky hobbies, and working on the intersection of code & craft.` (strikethrough on "engineering")
- **Merged Husband + Father** into a single `husband + dad` pill (Father button, subsection, and include removed)
- **Lowercased all pill titles** (builder, sommelier, marathoner, blimp pilot, chef)
- Rewrote **builder**, **sommelier** (Court of Master Sommeliers certified, Dec 2019), **marathoner** (NYC marathon, Nov 2025), **blimp pilot**, and **chef** copy
- chef pill keeps its "coming soon" badge with a `~~coming soon~~` strikethrough gag; blimp pilot keeps its badge too

### Styling
- Added a `blockquote` style (accent left-border + italic) to `landing.scss` for the marathon quote. The Meyer reset includes `em` in its `font: inherit` rule, which strips the default italic, so the italic is applied at the blockquote level.

## Test plan
- [x] `just build` compiles cleanly
- [x] Verified rendered `_site/index.html` reflects all copy changes
- [x] Confirmed the `<s>` strikethrough, `<blockquote>`, and compiled `font-style: italic` render
- [x] No stray `father` references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)