### PR TITLE
Add 1-click copy button for contact email

### DIFF
--- a/assets/css/landing.scss
+++ b/assets/css/landing.scss
@@ -286,6 +286,99 @@ body {
   }
 }
 
+.site-footer__contact {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.copy-email {
+  appearance: none;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.85rem;
+  height: 1.85rem;
+  padding: 0;
+  border: 1px solid $border-light;
+  border-radius: 6px;
+  background: $bg-card;
+  color: $text-muted;
+  cursor: pointer;
+  transition: color 0.2s, border-color 0.2s, background 0.2s;
+
+  &:hover {
+    color: $accent;
+    border-color: $accent;
+    background: $accent-light;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $accent;
+    outline-offset: 2px;
+  }
+}
+
+.copy-email__icon {
+  position: absolute;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.copy-email__icon--copy {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.copy-email__icon--check {
+  opacity: 0;
+  transform: scale(0.6);
+  color: #2e9e5b;
+}
+
+.copy-email.is-copied {
+  color: #2e9e5b;
+  border-color: #2e9e5b;
+  background: rgba(46, 158, 91, 0.08);
+
+  .copy-email__icon--copy {
+    opacity: 0;
+    transform: scale(0.6);
+  }
+
+  .copy-email__icon--check {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+// --------------------------------
+// Toast
+// --------------------------------
+
+.toast {
+  position: fixed;
+  left: 50%;
+  bottom: 2rem;
+  transform: translateX(-50%) translateY(1rem);
+  background: $text-primary;
+  color: #fff;
+  font-size: 0.9rem;
+  font-weight: 500;
+  padding: 0.65rem 1.1rem;
+  border-radius: 8px;
+  box-shadow: $shadow-md;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease, transform 0.25s ease;
+  z-index: 100;
+
+  &.is-visible {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+}
+
 // --------------------------------
 // Animation
 // --------------------------------

--- a/index.html
+++ b/index.html
@@ -39,9 +39,22 @@ layout: landing
   </div>
 
   <footer class="site-footer">
-    <p><a href="mailto:me@srogers.net">me@srogers.net</a></p>
+    <p class="site-footer__contact">
+      <a href="mailto:me@srogers.net">me@srogers.net</a>
+      <button type="button" class="copy-email" data-email="me@srogers.net" aria-label="Copy email to clipboard" title="Copy email to clipboard">
+        <svg class="copy-email__icon copy-email__icon--copy" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+        </svg>
+        <svg class="copy-email__icon copy-email__icon--check" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M20 6 9 17l-5-5"></path>
+        </svg>
+      </button>
+    </p>
   </footer>
 </div>
+
+<div class="toast" role="status" aria-live="polite"></div>
 
 <script>
   (function () {
@@ -60,6 +73,57 @@ layout: landing
           btn.classList.add('is-active');
           document.querySelector('[data-section="' + role + '"]').classList.add('is-visible');
         }
+      });
+    });
+  })();
+
+  (function () {
+    var copyBtn = document.querySelector('.copy-email');
+    var toast = document.querySelector('.toast');
+    if (!copyBtn || !toast) return;
+
+    var resetTimer;
+    var toastTimer;
+
+    function showToast(message) {
+      toast.textContent = message;
+      toast.classList.add('is-visible');
+      clearTimeout(toastTimer);
+      toastTimer = setTimeout(function () {
+        toast.classList.remove('is-visible');
+      }, 3000);
+    }
+
+    function copyText(text) {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        return navigator.clipboard.writeText(text);
+      }
+      return new Promise(function (resolve, reject) {
+        var temp = document.createElement('textarea');
+        temp.value = text;
+        temp.setAttribute('readonly', '');
+        temp.style.position = 'absolute';
+        temp.style.left = '-9999px';
+        document.body.appendChild(temp);
+        temp.select();
+        try {
+          document.execCommand('copy') ? resolve() : reject();
+        } catch (err) {
+          reject(err);
+        }
+        document.body.removeChild(temp);
+      });
+    }
+
+    copyBtn.addEventListener('click', function () {
+      var email = copyBtn.getAttribute('data-email');
+      copyText(email).then(function () {
+        copyBtn.classList.add('is-copied');
+        showToast('copied email to clipboard');
+        clearTimeout(resetTimer);
+        resetTimer = setTimeout(function () {
+          copyBtn.classList.remove('is-copied');
+        }, 10000);
       });
     });
   })();


### PR DESCRIPTION
Adds an inline icon button beside the mailto email that copies the
address to the clipboard on click. The icon animates from a copy glyph
to a checkmark, resets after 10 seconds, and triggers a toast reading
"copied email to clipboard".