### PR TITLE
Add code formatting to oura CLI command in oura-toolkit description

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -28,7 +28,7 @@
 
 - name: oura-toolkit
   year: 2026
-  description: "Your Oura Ring data, everywhere you work: a fast Rust CLI (oura), a local MCP server for AI assistants, a Claude plugin with wellness skills, and generated SDK clients. Data stays local, always privacy first."
+  description: "Your Oura Ring data, everywhere you work: a fast Rust CLI (<code>oura</code>), a local MCP server for AI assistants, a Claude plugin with wellness skills, and generated SDK clients. Data stays local, always privacy first."
   tags: [oura, rust, cli, homebrew, ai, mcp, plugin, npm]
   url: https://ouratoolkit.com
 


### PR DESCRIPTION
## Summary
- Wrap the `oura` CLI command name in `<code>` tags in the oura-toolkit project description on the homepage

## Test plan
- [ ] Verify the "oura-toolkit" project card renders `oura` in monospace/code formatting on the homepage


---
_Generated by [Claude Code](https://claude.ai/code/session_01BXhdPw4r29jFtL84UzBRfP)_