### PR TITLE
Add UTM tracking parameters to external project links

### DIFF
--- a/_includes/roles/builder.html
+++ b/_includes/roles/builder.html
@@ -17,7 +17,15 @@
     {% endif %}
   {% endcapture %}
   {% if project.url %}
-  <a class="project-card" href="{{ project.url }}"{% if project.url contains '://' %} target="_blank" rel="noopener"{% endif %}>{{ card_inner }}</a>
+  {% assign project_href = project.url %}
+  {% if project.url contains '://' %}
+    {% if project.url contains '?' %}
+      {% assign project_href = project.url | append: '&utm_source=spxrogers.com&utm_medium=referral&utm_campaign=builder-projects' %}
+    {% else %}
+      {% assign project_href = project.url | append: '?utm_source=spxrogers.com&utm_medium=referral&utm_campaign=builder-projects' %}
+    {% endif %}
+  {% endif %}
+  <a class="project-card" href="{{ project_href }}"{% if project.url contains '://' %} target="_blank" rel="noopener"{% endif %}>{{ card_inner }}</a>
   {% else %}
   <div class="project-card project-card--static">{{ card_inner }}</div>
   {% endif %}

--- a/_includes/roles/builder.html
+++ b/_includes/roles/builder.html
@@ -19,13 +19,14 @@
   {% if project.url %}
   {% assign project_href = project.url %}
   {% if project.url contains '://' %}
-    {% if project.url contains '?' %}
-      {% assign project_href = project.url | append: '&utm_source=spxrogers.com&utm_medium=referral&utm_campaign=builder-projects' %}
-    {% else %}
-      {% assign project_href = project.url | append: '?utm_source=spxrogers.com&utm_medium=referral&utm_campaign=builder-projects' %}
+    {% assign url_parts = project.url | split: '#' %}
+    {% if url_parts[0] contains '?' %}{% assign utm_sep = '&' %}{% else %}{% assign utm_sep = '?' %}{% endif %}
+    {% assign project_href = url_parts[0] | append: utm_sep | append: 'utm_source=spxrogers.com&utm_medium=referral&utm_campaign=builder-projects' %}
+    {% if url_parts.size > 1 %}
+      {% assign project_href = project_href | append: '#' | append: url_parts[1] %}
     {% endif %}
   {% endif %}
-  <a class="project-card" href="{{ project_href }}"{% if project.url contains '://' %} target="_blank" rel="noopener"{% endif %}>{{ card_inner }}</a>
+  <a class="project-card" href="{{ project_href | escape }}"{% if project.url contains '://' %} target="_blank" rel="noopener"{% endif %}>{{ card_inner }}</a>
   {% else %}
   <div class="project-card project-card--static">{{ card_inner }}</div>
   {% endif %}


### PR DESCRIPTION
## Summary

Add UTM tracking parameters to external project links in the builder section to track referral traffic from the portfolio.

## Changes

- Modified the project card link generation in `_includes/roles/builder.html` to append UTM parameters (`utm_source=spxrogers.com&utm_medium=referral&utm_campaign=builder-projects`) to external URLs
- Intelligently handles URL construction by detecting existing query parameters and using `?` or `&` as appropriate
- UTM parameters are only added to external URLs (those containing `://`), leaving internal links unchanged

## Implementation Details

The change uses Liquid template logic to:
1. Detect if a project URL is external (contains `://`)
2. Check if the URL already has query parameters
3. Append UTM parameters with the correct separator (`?` for new parameters, `&` for existing ones)
4. Maintain the existing `target="_blank"` and `rel="noopener"` behavior for external links

This enables analytics tracking of which portfolio projects drive traffic back to the site.

https://claude.ai/code/session_018xU8eoiqsn4wG7hPTiDo5i